### PR TITLE
Follow Milky protocol changes during [July 29, August 11]

### DIFF
--- a/src/nonebot/adapters/milky/bot.py
+++ b/src/nonebot/adapters/milky/bot.py
@@ -271,7 +271,6 @@ class Bot(BaseBot):
         *,
         message_scene: str,
         peer_id: int,
-        direction: Literal["newer", "older"],
         start_message_seq: Optional[int] = None,
         limit: int = 20,
     ) -> list[IncomingMessage]:
@@ -280,7 +279,6 @@ class Bot(BaseBot):
         Args:
             message_scene: 消息场景
             peer_id: 好友 QQ 号或群号
-            direction: 消息获取方向
             start_message_seq: 起始消息序列号，不提供则从最新消息开始
             limit: 获取的最大消息数量
         Returns:

--- a/src/nonebot/adapters/milky/bot.py
+++ b/src/nonebot/adapters/milky/bot.py
@@ -3,7 +3,7 @@ from io import BytesIO
 from pathlib import Path
 from collections.abc import Sequence
 from typing_extensions import override
-from typing import TYPE_CHECKING, Any, Union, Literal, Optional
+from typing import TYPE_CHECKING, Any, Union, Optional
 
 from nonebot.message import handle_event
 from nonebot.compat import type_validate_python
@@ -396,7 +396,7 @@ class Bot(BaseBot):
     @api
     async def get_cookies(self, *, domain: str):
         """获取指定域名的 Cookie"""
-        result = await self._call("get_cookies", locals())
+        result = await self._call("get_cookies", {"domain": domain})
         return result["cookies"]
 
     @api

--- a/src/nonebot/adapters/milky/bot.py
+++ b/src/nonebot/adapters/milky/bot.py
@@ -396,6 +396,18 @@ class Bot(BaseBot):
         return type_validate_python(Member, result["member"])
 
     @api
+    async def get_cookies(self, *, domain: str):
+        """获取指定域名的 Cookie"""
+        result = await self._call("get_cookies", locals())
+        return result["cookies"]
+
+    @api
+    async def get_csrf_token(self):
+        """获取 CSRF Token"""
+        result = await self._call("get_csrf_token")
+        return result["csrf_token"]
+
+    @api
     async def send_friend_nudge(self, *, user_id: int, is_self: bool = False) -> None:
         """发送好友头像双击动作"""
         await self._call("send_friend_nudge", locals())

--- a/src/nonebot/adapters/milky/bot.py
+++ b/src/nonebot/adapters/milky/bot.py
@@ -406,7 +406,7 @@ class Bot(BaseBot):
         await self._call("send_profile_like", locals())
 
     @api
-    async def set_group_name(self, *, group_id: int, name: str) -> None:
+    async def set_group_name(self, *, group_id: int, new_group_name: str) -> None:
         """设置群名称"""
         await self._call("set_group_name", locals())
 
@@ -784,13 +784,13 @@ class Bot(BaseBot):
         await self._call("move_group_file", locals())
 
     @api
-    async def rename_group_file(self, *, group_id: int, file_id: str, new_name: str) -> None:
+    async def rename_group_file(self, *, group_id: int, file_id: str, new_file_name: str) -> None:
         """重命名群文件
 
         Args:
             group_id: 群号
             file_id: 文件 ID
-            new_name: 新文件名
+            new_file_name: 新文件名
         """
         await self._call("rename_group_file", locals())
 
@@ -818,13 +818,13 @@ class Bot(BaseBot):
         return result["folder_id"]
 
     @api
-    async def rename_group_folder(self, *, group_id: int, folder_id: str, new_name: str) -> None:
+    async def rename_group_folder(self, *, group_id: int, folder_id: str, new_folder_name: str) -> None:
         """重命名群文件夹
 
         Args:
             group_id: 群号
             folder_id: 文件夹 ID
-            new_name: 新文件夹名
+            new_folder_name: 新文件夹名
         """
         await self._call("rename_group_folder", locals())
 

--- a/src/nonebot/adapters/milky/event.py
+++ b/src/nonebot/adapters/milky/event.py
@@ -415,7 +415,7 @@ class GroupNameChangeData(ModelBase):
     group_id: int
     """群号"""
 
-    name: str
+    new_group_name: str
     """新的群名称"""
 
     operator_id: int

--- a/src/nonebot/adapters/milky/message.py
+++ b/src/nonebot/adapters/milky/message.py
@@ -120,7 +120,7 @@ class MessageSegment(BaseMessageSegment["Message"]):
         segments: "Message",
     ) -> "OutgoingForwardedMessage":
         """合并转发消息节点"""
-        return OutgoingForwardedMessage(user_id=user_id, name=name, segments=segments)
+        return OutgoingForwardedMessage(user_id=user_id, sender_name=name, segments=segments)
 
 
 class TextData(TypedDict):
@@ -219,7 +219,7 @@ class IncomingForwardData(TypedDict):
 @dataclass
 class OutgoingForwardedMessage:
     user_id: int
-    name: str
+    sender_name: str
     segments: list[MessageSegment]
 
 
@@ -240,7 +240,7 @@ class Forward(MessageSegment):
                     "messages": [
                         OutgoingForwardedMessage(
                             user_id=msg["user_id"],
-                            name=msg["name"],
+                            sender_name=msg["name"],
                             segments=Message.from_elements(msg["segments"]),
                         )
                         for msg in data["messages"]
@@ -258,7 +258,7 @@ class Forward(MessageSegment):
                 "messages": [
                     {
                         "user_id": message.user_id,
-                        "name": message.name,
+                        "sender_name": message.sender_name,
                         "segments": [seg.dump() for seg in message.segments],
                     }
                     for message in self.data["messages"]
@@ -346,7 +346,7 @@ class Message(BaseMessage[MessageSegment]):
                 new.append(
                     MessageSegment.forward(
                         # TODO: 拿 user_id
-                        [MessageSegment.node(int(bot.self_id), msg.name, msg.message) for msg in messages]
+                        [MessageSegment.node(int(bot.self_id), msg.sender_name, msg.message) for msg in messages]
                     )
                 )
             elif isinstance(seg, (MarketFace, LightAPP, XML)):

--- a/src/nonebot/adapters/milky/model/common.py
+++ b/src/nonebot/adapters/milky/model/common.py
@@ -75,7 +75,7 @@ class Group(ModelBase):
     group_id: int
     """群号"""
 
-    name: str
+    group_name: str
     """群名"""
 
     member_count: int
@@ -116,6 +116,9 @@ class Member(ModelBase):
 
     last_sent_time: int
     """成员最后发言时间"""
+
+    shut_up_end_time: Optional[int] = None
+    """成员禁言结束时间"""
 
 
 class Announcement(ModelBase):

--- a/src/nonebot/adapters/milky/model/event.py
+++ b/src/nonebot/adapters/milky/model/event.py
@@ -48,7 +48,7 @@ class IncomingMessage(ModelBase):
 class IncomingForwardedMessage(ModelBase):
     """接收的转发消息"""
 
-    name: str
+    sender_name: str
     """发送者名称"""
 
     avatar_url: str


### PR DESCRIPTION
This pull request implements Milky's latest changes as follows:

## July 29 Update

https://github.com/SaltifyDev/milky/commit/c741ccbbcf25dd371182a2e233d89a9ba80110b1

为 GroupMember 增加了 shut_up_end_time 字段（可选），用于表示群成员禁言解除的时刻（若有）。

## August 4 Update

https://github.com/SaltifyDev/milky/commit/496a05f02fc4f4c1cabad70e21d9c522afd9e669

移除了 get_history_messages 的 direction 字段，现在所有的历史获取行为均是由新到旧获取。

## August 10 Update

https://github.com/SaltifyDev/milky/commit/b97cf07176336195048701d621515ef70cfc182f

标准化了含 name 的字段的命名。

目前命名标准是：XxxEntity 的“名称”有关的字段是 `xxx_name`；如果有相关的 set_xxx_name 或 rename_xxx API，抑或是有名称改变的事件，则此类 API 中用于指定新命名的字段名为 `new_xxx_name`。

具体的修改有：

rename_group_file 的输入参数，`new_name` -> `new_file_name`
rename_group_folder 的输入参数，`new_name` -> `new_folder_name`
GroupEntity 的字段，`name` -> `group_name`
set_group_name 的输入参数，`name` -> `new_group_name`
group_name_change 事件的字段，`name` -> `new_group_name`
IncomingForwardedMessage 和 OutgoingForwardedMessage 的字段，`name` -> `sender_name`

## August 11 Update

https://github.com/SaltifyDev/milky/commit/7385ec6d364f4c32e57b4501de3b7eeaa18717ca

增加了有关获取 Cookies 和 CSRF Token 的 API。